### PR TITLE
Replace experiments submodule folder with netlify redirects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "themes/cactus-dark"]
 	path = themes/cactus-dark
 	url = git@github.com:dharFr/cactus-dark.git
-[submodule "experiments/lone-star"]
-	path = experiments/lone-star
-	url = git@github.com:dharFr/lone-star.git

--- a/netlify/_redirects
+++ b/netlify/_redirects
@@ -15,7 +15,7 @@
 # Initialy hosted lone-star as a submodule on that path, 
 # before using proxy redirect bellow. 
 # Keeping backward compatibility just in case
-/experiments/lone-star/   lone-star/
+/experiments/lone-star/   /lone-star/
 
 # Proxy redirects
 /twitter/* https://twitter-dhar.netlify.app/:splat 200!

--- a/netlify/_redirects
+++ b/netlify/_redirects
@@ -12,8 +12,15 @@
 /blog/categories/*  /410.html         410
 /blog/page/*        /410.html         410
 
+# Initialy hosted lone-star as a submodule on that path, 
+# before using proxy redirect bellow. 
+# Keeping backward compatibility just in case
+/experiments/lone-star/   lone-star/
+
 # Proxy redirects
 /twitter/* https://twitter-dhar.netlify.app/:splat 200!
+/the-way-we-move/* https://the-way-we-move.netlify.app/:splat 200!
+/lone-star/* https://oaudard-lone-star.netlify.app/:splat 200!
 
 # Google search console fixes
 /blog/2012/10/28/a-quick-talk-about-grunt           /blog/2012/10/28/adding-grunt-to-your-web-application-project/

--- a/source/_data/projects.json
+++ b/source/_data/projects.json
@@ -1,7 +1,7 @@
  [
    {
       "name":"Lone Star",
-      "url":"/experiments/lone-star/",
+      "url":"/lone-star/",
       "desc":"Playing with lines and randomness using p5.js and canvas API. Yet another attempt to _Code like no one's watching_"
    },
    {
@@ -11,7 +11,7 @@
    },
    {
       "name":"The Way We Move",
-      "url":"https://the-way-we-move.surge.sh/",
+      "url":"/the-way-we-move/",
       "desc":"Let's play with canvas drawing and WebAudio API, see if something interesting might appear. A first attempt to Code like no one's watching."
    },
    {

--- a/source/experiments/lone-star
+++ b/source/experiments/lone-star
@@ -1,1 +1,0 @@
-../../experiments/lone-star/src


### PR DESCRIPTION
I started regrouping all my side-projects hosting on netlify. This is also a good opportunity to give them a refresh.

 - [x] Add redirect to newly deployed version of `/the-way-we-move/` (previously hosted on surge.sh)
 - [x] Replace `experiments/lone-star` submodule with a redirect 
