### PR TITLE
Better feeds management

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,9 +71,28 @@ theme: cactus-dark
 deploy:
 
 # hexo-generator-feed plugin
+# feed:
+#   type: atom
+#   path: atom.xml
+
+# hexo-feed plugin
 feed:
-  type: atom
-  path: atom.xml
+  #limit: 20
+  #order_by: "-date"
+  tag_dir: tags
+  category_dir: /
+  rss:
+    enable: true
+    #template: "themes/theme/layout/_alternate/rss.ejs"
+    output: rss.xml
+  atom:
+    enable: true
+    #template: "themes/theme/layout/_alternate/atom.ejs"
+    output: atom.xml
+  jsonFeed:
+    enable: true
+    #template: "themes/theme/layout/_alternate/json.ejs"
+    output: feed.json
 
 # hexo-generator-tag plugin
 tag_generator:
@@ -255,7 +274,7 @@ theme_config:
   ##############################################################################
 
   # Enable or disable the RSS feed.
-  rss: 
+  rss: "hexo-feed"
 
   # Turn your web pages into graph objects (see http://ogp.me).
   open_graph:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dhar/url-courte": "^1.0.0",
         "hexo": "^6.3.0",
+        "hexo-feed": "^1.1.1",
         "hexo-generator-archive": "^2.0.0",
         "hexo-generator-category": "^2.0.0",
         "hexo-generator-feed": "^3.0.0",
@@ -927,6 +928,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hexo-feed": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hexo-feed/-/hexo-feed-1.1.1.tgz",
+      "integrity": "sha512-Hrp6YZGZ93/EqGOAvKll8hQpCWKggcbexP3Xkjx00YCUeOHGSNqBLdggRGAo8c7/BPbF6X0wLgar/WD+f5hKYQ==",
+      "peerDependencies": {
+        "chalk": "^4.1.0",
+        "hexo": "^4.2.0 || ^5.2.0 || ^6.1.0"
       }
     },
     "node_modules/hexo-front-matter": {
@@ -3355,6 +3365,12 @@
           }
         }
       }
+    },
+    "hexo-feed": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hexo-feed/-/hexo-feed-1.1.1.tgz",
+      "integrity": "sha512-Hrp6YZGZ93/EqGOAvKll8hQpCWKggcbexP3Xkjx00YCUeOHGSNqBLdggRGAo8c7/BPbF6X0wLgar/WD+f5hKYQ==",
+      "requires": {}
     },
     "hexo-front-matter": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@dhar/url-courte": "^1.0.0",
     "hexo": "^6.3.0",
+    "hexo-feed": "^1.1.1",
     "hexo-generator-archive": "^2.0.0",
     "hexo-generator-category": "^2.0.0",
     "hexo-generator-feed": "^3.0.0",


### PR DESCRIPTION
 - Replace [hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed) with [hexo-feed](https://github.com/sergeyzwezdin/hexo-feed) plugin
 - Enable per categroy feeds
 - Add RSS & JSON feeds in addition to Atom